### PR TITLE
Remove outdated node engine part

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,9 +71,5 @@
   "peerDependencies": {
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
-  },
-  "engines": {
-    "node": "8.11.2",
-    "npm": "6.4.1"
   }
 }


### PR DESCRIPTION
Hi there

Because of outdated engine part in package.json file, I was unable to use this repo from npm, please consider removing this part, or at-least update it to accept higher node versions as well.

Thanks