### PR TITLE
fix "Cannot read property 'setState' of undefined" error when clicking on [x] button of timepicker

### DIFF
--- a/src/components/CustomTimePicker.js
+++ b/src/components/CustomTimePicker.js
@@ -31,8 +31,8 @@ export default class MyTimePicker extends Component {
       newValue = moment(value);
     }
 
-    newValue.hour(value.hour());
-    newValue.minute(value.minute());
+    newValue.hour(value ? value.hour() : null);
+    newValue.minute(value ? value.minute() : null);
 
     this.props.setMomentValue(newValue);
   }

--- a/src/components/TimePicker/Header.js
+++ b/src/components/TimePicker/Header.js
@@ -31,6 +31,9 @@ class Header extends React.Component {
       str: (value && value.format(format)) || '',
       invalid: false,
     };
+    this.onClear = this.onClear.bind(this)
+    this.onInputChange = this.onInputChange.bind(this)
+    this.onKeyDown = this.onKeyDown.bind(this)
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
When timepicker [x] button is clicked, nothing happen and "Cannot read property 'setState' of undefined" error appear in developer console; in this commit, that bug fixed.