### PR TITLE
Specify the today button type to avoid submitting a parent form

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -218,7 +218,7 @@ export class Calendar extends Component {
     return (
       <div className={`${styles.calendarContainer} ${jalaaliClassName}${className}`}>
         {mode === 'monthSelector' ? this.renderMonthSelector() : this.renderDays()}
-        <button className="selectToday" onClick={() => this.handleClickOnDay(moment())}>
+        <button type="button" className="selectToday" onClick={() => this.handleClickOnDay(moment())}>
           {isGregorian ? 'today' : 'امروز'}
         </button>
       </div>


### PR DESCRIPTION
Hello, I made this change because in my case I used the calendar in a form and it was submitting when clicking on the today button.
So at first I added an event.preventDefault() at the onClick but I tried to just specify the button type and it seems to be working :)
Tell me if I need to do something else as it's my first PR !
Thanks and have a good day.