### PR TITLE
Fix touch event for mobile

### DIFF
--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -336,6 +336,7 @@ export default class DatePicker extends Component {
               />
             ) : null
           }
+          eventType={["click", "touch"]}
         />
       </div>
     );


### PR DESCRIPTION
The default value for `eventType` in `react-onclickoutside` is `["click", "touchstart"]`.

`touchstart` will cause datepicker closed when user want to scroll the page ( since the datepicker may show with scroll, it's not what expepted ).

So I changed event type from `touchstart` to `touch`. if user touch the outside ( tap ) the datepicker will be closed and if want to scroll noting will happend.